### PR TITLE
clean up env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+.env.dev
 
 # macOS-specific files
 .DS_Store

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,7 +20,6 @@ export default defineConfig({
     schema: {
       STAGING: envField.boolean({ context: "server", access:"public", default: false }),
       FIVECALLS_API: envField.string({ context: "server", access:"secret" }),
-      DRIVE_CREDENTIALS: envField.string({ context: "server", access:"secret" }),
       GOOGLE_TOKEN: envField.string({ context: "server", access:"secret" }),
     }
   },


### PR DESCRIPTION
- don't need the credential files server-side
- use a different token for dev